### PR TITLE
Fix markers not appearing

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -16,7 +16,7 @@ function CountCops()
 			copsConnected = copsConnected + 1
 		end
 	end
-	TriggerClientEvent('esx_advanced_robbery:copsConnected', -1, copsConnected)
+	TriggerClientEvent('esx_advanced_holdup:copsConnected', -1, copsConnected)
 
 	SetTimeout(60000, CountCops)
 


### PR DESCRIPTION
This fixes the markers not appearing when the minimum police is set to a value higher than 0